### PR TITLE
extend ir library with 'button held' semantics

### DIFF
--- a/src/locoboard.cpp
+++ b/src/locoboard.cpp
@@ -145,15 +145,28 @@ bool check_ir_button_pressed()
 {
   if(TinyReceiverDecode())
   {
+    if(remote.held && remote.button == TinyIRReceiverData.Command)
+      return false;
+
     remote.button = TinyIRReceiverData.Command;
+    remote.held = true;
     return true;
   }
-  else return false;
+  else
+  {
+    remote.held = false;
+    return false;
+  };
 }
 
 unsigned char get_ir_button()
 {
   return remote.button;
+}
+
+bool get_ir_held()
+{
+  return remote.held;
 }
 #endif
 

--- a/src/locoboard.cpp
+++ b/src/locoboard.cpp
@@ -143,8 +143,11 @@ void setup_ir()
 
 bool check_ir_button_pressed()
 {
+  unsigned long now = millis();
   if(TinyReceiverDecode())
   {
+    remote.last = now;
+
     if(remote.held && remote.button == TinyIRReceiverData.Command)
       return false;
 
@@ -152,11 +155,10 @@ bool check_ir_button_pressed()
     remote.held = true;
     return true;
   }
-  else
-  {
+  else if((now - remote.last) > REMOTE_INTERVAL_MS)
     remote.held = false;
-    return false;
-  };
+
+  return false;
 }
 
 unsigned char get_ir_button()

--- a/src/locoboard.h
+++ b/src/locoboard.h
@@ -60,6 +60,7 @@
 typedef struct {
   unsigned char button;
   unsigned char keypress_registered;
+  bool held;
 } Remote;
 #endif
 
@@ -85,6 +86,7 @@ int measure_distance_mm(unsigned char sensor_id);
 void setup_ir();
 bool check_ir_button_pressed();
 unsigned char get_ir_button();
+bool get_ir_held();
 #endif
 
 #ifdef USE_POTENTIOMETER

--- a/src/locoboard.h
+++ b/src/locoboard.h
@@ -61,6 +61,7 @@ typedef struct {
   unsigned char button;
   unsigned char keypress_registered;
   bool held;
+  unsigned long last;
 } Remote;
 #endif
 
@@ -83,6 +84,7 @@ int measure_distance_mm(unsigned char sensor_id);
 
 #ifdef USE_REMOTE
 //Remote
+#define REMOTE_INTERVAL_MS 1000/8
 void setup_ir();
 bool check_ir_button_pressed();
 unsigned char get_ir_button();


### PR DESCRIPTION
Added a solution as discussed, `check_ir_button_pressed` only returns true for 'rising edges' (as polled by the user).
Tested for compilation, but haven't tested for functionality on a real board. `get_ir_held()` returns `true` if the button is currently pressed and held.

Template:  [template.zip](https://github.com/user-attachments/files/17215035/template.zip)
Demo (please test): [demo.zip](https://github.com/user-attachments/files/17215050/demo.zip)

Potential issue with this solution: For long operations (e.g., turning), separate keypresses might not trigger a rising edge. Users should utilise `check_ir_button_pressed() || get_ir_held()` for pressed-or-held semantics used in long-running loops that intrinsically guard against repeat presses.

IRremote claims to mitigate (some kind) of repeat frame problem, but looking at the [source code](https://github.com/Arduino-IRremote/Arduino-IRremote/blob/610d1165edb9d8d8a47974957ebb350fdd82cfe8/src/TinyIRReceiver.hpp#L434), I believe that's meant for sub-beam intervals (i.e., wall reflections).